### PR TITLE
Fix for support on Alpine and others musl-based distros

### DIFF
--- a/bin/phulp.php
+++ b/bin/phulp.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Finder\Finder;
+
 ini_set('register_argc_argv', true);
 
 $getArg = function ($arg, $isOption = true) use (&$argv) {
@@ -142,7 +144,11 @@ if (count($argv) > 1) {
     }
 }
 
-$phulpFiles = glob('[P,p]hulp[Ff]il{e,e.php}', GLOB_BRACE);
+$phulpFiles = [];
+$finder = Finder::create()->name('~^phulpfile(\.php)*$~i')->depth('< 1')->in(getcwd())->getIterator();
+foreach ($finder as $file) {
+    $phulpFiles[] = $file->getFilename();
+}
 
 if (count($phulpFiles) > 1) {
     $out::err(sprintf(


### PR DESCRIPTION
Alpine Linux doesn't support GLOB_BRACE since it is using musl libc instead of GNU libc.

I was trying to compile static assets on an Alpine Linux Docker container (popular case). I was unable to, because there is a error around usage of the GLOB_BRACE constant, which may or may not be defined depending on the environment, and isn't defined/worked in Alpine Linux.

Using an Alpine Linux PHP Docker container, for running Phulp:
PHP 7.1 (Alpine Linux 3.7)

The following:

 [Exception]
 Notice: Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' in /app/php_packages/reisraff/phulp/bin/phulp.php on line 145
...

